### PR TITLE
Fix Symfony deprecation

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -10,7 +10,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('sirian_suggest');
         if (method_exists($treeBuilder, 'getRootNode')) {
@@ -29,8 +29,6 @@ class Configuration implements ConfigurationInterface
                     ->prototype('variable')
                     ->end()
                 ->end()
-
-
 
         ;
 


### PR DESCRIPTION
Since Symfony 5.4 it says
```
* 1x: Method "Symfony\Component\Config\Definition\ConfigurationInterface::getConfigTreeBuilder()" might add "TreeBuilder" as a native return type declaration in the future. Do the same in implementation "Sirian\SuggestBundle\DependencyInjection\Configuration" now to avoid errors or add an explicit @return annotation to suppress this message.
```